### PR TITLE
Add history page and improve docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .DS_Store
+node_modules/
+.next/
+npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Eclipse
 
-This is a basic setup for a Next.js project using TypeScript and Tailwind CSS.
+This project shows one question per day that can be answered only once. It is
+built with Next.js, TypeScript and Tailwind CSS.
 
 ## Available Scripts
 
@@ -12,3 +13,12 @@ This is a basic setup for a Next.js project using TypeScript and Tailwind CSS.
 
 - `pages/` – Application pages and API routes
 - `styles/` – Global styles powered by Tailwind CSS
+
+## Using Daily Questions
+
+Questions for each date are stored in `public/questions.json`.  Update this file
+to change or add new questions.  You can view a question by navigating to
+`/today` or by specifying a date directly, e.g. `/today?date=2023-01-01`.
+
+Submitted answers are stored on the server under `data/answers.json` and can be
+viewed on the **History** page.

--- a/pages/history.tsx
+++ b/pages/history.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+
+interface Answers {
+  [date: string]: string;
+}
+
+const HistoryPage = () => {
+  const [answers, setAnswers] = useState<Answers>({});
+
+  useEffect(() => {
+    fetch('/api/answers')
+      .then((res) => res.json())
+      .then((data) => setAnswers(data));
+  }, []);
+
+  const dates = Object.keys(answers).sort();
+
+  if (dates.length === 0) {
+    return <p className="p-4">답변 내역이 없습니다.</p>;
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">지난 답변</h1>
+      <ul className="space-y-2">
+        {dates.map((date) => (
+          <li key={date}>
+            <strong>{date}</strong>
+            <p>{answers[date]}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default HistoryPage;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,9 +1,16 @@
 import type { NextPage } from 'next';
+import Link from 'next/link';
 
 const Home: NextPage = () => {
   return (
-    <div className="flex items-center justify-center min-h-screen">
-      <h1 className="text-2xl font-bold">Welcome to Next.js with Tailwind CSS and TypeScript!</h1>
+    <div className="flex flex-col items-center justify-center min-h-screen space-y-4">
+      <h1 className="text-2xl font-bold">Welcome to Eclipse</h1>
+      <Link href="/today" className="px-4 py-2 bg-blue-500 text-white rounded">
+        오늘의 질문 보러가기
+      </Link>
+      <Link href="/history" className="px-4 py-2 bg-gray-500 text-white rounded">
+        지난 답변 보기
+      </Link>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- provide easy nav to /today and history from index
- show previous answers on new `/history` page
- document daily questions and history usage
- add common Node ignores

## Testing
- `npm run lint` *(fails: `next` not found)*